### PR TITLE
Add a link to fluentd.org in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# fluent-plugin-derive
+# fluent-plugin-derive, a plugin for [Fluentd](http://fluentd.org)
 
 Calculate per second value for the increasing/decreasing value between the last and the current, like derive in RRDTool.
 


### PR DESCRIPTION
I am adding a link to Fluentd.org in your README.md file to put Fluentd in context for newcomers.
