### PR TITLE
Add interval_division option

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Define the expected range value. If min and/or max are specified any value outsi
 
 Define the expected range value. If min and/or max are specified any value outside the defined range will be truncated.
 
-* interval_division
+* time_unit_division
 
 Optional. Divide the incleased value by interval time before output. The default is `true`. Set `false` for disable dividing.
 

--- a/lib/fluent/plugin/out_derive.rb
+++ b/lib/fluent/plugin/out_derive.rb
@@ -14,7 +14,7 @@ class Fluent::DeriveOutput < Fluent::Output
   config_param :remove_tag_prefix, :string, :default => nil
   config_param :min, :integer, :default => nil
   config_param :max, :integer, :default => nil
-  config_param :interval_division, :bool, :default => true
+  config_param :time_unit_division, :bool, :default => true
 
   # for test
   attr_reader :key_pattern
@@ -156,7 +156,7 @@ class Fluent::DeriveOutput < Fluent::Output
       log.warn "Could not calculate the rate. multiple input less than one second or minus delta of seconds on tag=#{tag}, key=#{key}"
       return nil
     end
-    if @interval_division
+    if @time_unit_division
       rate = (cur_value - prev_value)/(cur_time - prev_time)
     else
       rate = cur_value - prev_value

--- a/spec/out_derive_spec.rb
+++ b/spec/out_derive_spec.rb
@@ -282,11 +282,11 @@ describe Fluent::DeriveOutput do
         }
       end
 
-      context 'no interval_division' do
+      context 'time_unit_division false' do
         let(:config) { %[
           tag rate
           key1 foo
-          interval_division false
+          time_unit_division false
         ]}
         before do
           driver.run {


### PR DESCRIPTION
To emit the raw incleased value which is not divided by time interval, add `interval_division` .
The default value of `interval_division` is `true` and is optional, so no default behavior will be changed.
